### PR TITLE
Update to current versions shipped with Fiji

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+cache:
+  directories:
+  - "~/.m2/repository"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://travis-ci.com/adaerr/pendent-drop.svg?branch=master)](https://travis-ci.com/adaerr/pendent-drop)
+
 Pendent Drop ImageJ plugin
 ==========================
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>23.2.0</version>
+		<version>24.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,17 @@
 		<url>https://github.com/adaerr/pendent-drop/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>None</system>
+		<system>Travis CI</system>
+		<url>https://travis-ci.com/adaerr/pendent-drop</url>
 	</ciManagement>
 
 	<properties>
 		<main-class>Goutte_pendante</main-class>
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Adrian Daerr</license.copyrightOwners>
+
+		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
+		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>net.imagej</groupId>
-		<artifactId>pom-imagej</artifactId>
-		<version>7.1.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>23.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -17,11 +14,68 @@
 	<version>2.0.5-SNAPSHOT</version>
 
 	<name>Pendent Drop ImageJ Plugin</name>
-	<description>Surface tension measurement through the pendent
-	drop method.</description>
+	<description>Surface tension measurement through the pendent drop method.</description>
+	<url>https://github.com/adaerr/pendent-drop</url>
+	<inceptionYear>2013</inceptionYear>
+	<organization>
+		<name>Université Paris Diderot</name>
+		<url>https://www.univ-paris-diderot.fr/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v3+</name>
+			<url>http://www.gnu.org/licenses/gpl.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Adrian Daerr</name>
+			<id>adaerr</id>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Adrien Mogne</name>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/adaerr/pendent-drop</connection>
+		<developerConnection>scm:git:git@github.com:adaerr/pendent-drop</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/adaerr/pendent-drop</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/adaerr/pendent-drop/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>None</system>
+	</ciManagement>
 
 	<properties>
 		<main-class>Goutte_pendante</main-class>
+		<license.licenseName>gpl_v3</license.licenseName>
+		<license.copyrightOwners>Adrian Daerr</license.copyrightOwners>
 	</properties>
 
 	<repositories>
@@ -36,6 +90,9 @@
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+		</dependency>
 	</dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	drop method.</description>
 
 	<properties>
-		<main-class>Goutte_Pendante</main-class>
+		<main-class>Goutte_pendante</main-class>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>name.adriandaerr.imagejplugins.pendentdrop</groupId>
 	<artifactId>pendent_drop</artifactId>
-	<version>2.0.4</version>
+	<version>2.0.5-SNAPSHOT</version>
 
 	<name>Pendent Drop ImageJ Plugin</name>
 	<description>Surface tension measurement through the pendent

--- a/src/main/java/Goutte_pendante.java
+++ b/src/main/java/Goutte_pendante.java
@@ -49,8 +49,6 @@ import net.imagej.display.ImageDisplay;
 import net.imagej.display.OverlayService;
 import net.imagej.overlay.Overlay;
 import net.imagej.overlay.RectangleOverlay;
-import net.imagej.table.DefaultGenericTable;
-import net.imagej.table.GenericTable;
 
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
@@ -62,6 +60,8 @@ import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.ServiceHelper;
+import org.scijava.table.DefaultGenericTable;
+import org.scijava.table.GenericTable;
 import org.scijava.util.Colors;
 import org.scijava.util.RealRect;
 import org.scijava.widget.Button;


### PR DESCRIPTION
This updates the POM to current SciJava best practices, including extending pom-scijava with metadata fields populated.

It also adjusts for backwards incompatibilities in the ImageJ (now SciJava) Table API.