### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>24.0.0</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -78,14 +78,14 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Adrian Daerr</license.copyrightOwners>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>name.adriandaerr.imagejplugins.pendentdrop</groupId>
 	<artifactId>pendent_drop</artifactId>
-	<version>2.0.5</version>
+	<version>2.0.6-SNAPSHOT</version>
 
 	<name>Pendent Drop ImageJ Plugin</name>
 	<description>Surface tension measurement through the pendent drop method.</description>


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.